### PR TITLE
Adding logging levels

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -22,6 +22,7 @@ return [
                 true
             );
         },
+        'level' => env('CLOUDWATCH_LOG_LEVEL', 'info'),
         'via' => \Pagevamp\Logger::class
     ],
 ];

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,8 @@ Config for logging is defined at `config/logging.php`. Add `cloudwatch` to the `
             'group_name' => env('CLOUDWATCH_LOG_GROUP_NAME', 'laravel_app'),
             'version' => env('CLOUDWATCH_LOG_VERSION', 'latest'),
             'formatter' => \Monolog\Formatter\JsonFormatter::class,       
-            'batch_size' => env('CLOUDWATCH_LOG_BATCH_SIZE', 10000),    
+            'batch_size' => env('CLOUDWATCH_LOG_BATCH_SIZE', 10000),  
+            'level' => env('CLOUDWATCH_LOG_LEVEL', 'info'), 
             'via' => \Pagevamp\Logger::class,
         ],
 ]

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -29,10 +29,12 @@ class Logger
         $streamName = $loggingConfig['stream_name'];
         $retentionDays = $loggingConfig['retention'];
         $groupName = $loggingConfig['group_name'];
+        $level = isset($loggingConfig['level']) ? $loggingConfig['level'] : 'info';
         $batchSize = isset($loggingConfig['batch_size']) ? $loggingConfig['batch_size'] : 10000;
 
-        $logHandler = new CloudWatch($cwClient, $groupName, $streamName, $retentionDays, $batchSize);
         $logger = new \Monolog\Logger($loggingConfig['name']);
+        $monologLevel = $logger::toMonologLevel($level);
+        $logHandler = new CloudWatch($cwClient, $groupName, $streamName, $retentionDays, $batchSize, [], $monologLevel);
 
         $formatter = $this->resolveFormatter($loggingConfig);
         $logHandler->setFormatter($formatter);


### PR DESCRIPTION
### Logging Levels

#### Changes:
- Added ability to use Laravels default level configuration option.
- Updated README.md & logging.php to reflect ability to use level configuration option.

#### Use Case:
Some users may not wish for all log levels to be streamed to CloudWatch as this can lead to bloat, making debugging more difficult.
